### PR TITLE
Fix the config/specs problems including constants in module

### DIFF
--- a/lib/config/dry_validation_requirements.rb
+++ b/lib/config/dry_validation_requirements.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Config
   DRY_VALIDATION_REQUIREMENTS = ['~> 1.0', '>= 1.0.0'].freeze
 end

--- a/lib/config/validation/schema.rb
+++ b/lib/config/validation/schema.rb
@@ -1,5 +1,5 @@
-require_relative "../dry_validation_requirements"
-require_relative "../error"
+load 'config/dry_validation_requirements.rb'
+require_relative '../error'
 
 module Config
   module Validation
@@ -13,16 +13,17 @@ module Config
         if block_given?
           begin
             require 'dry/validation/version'
+
             version = Gem::Version.new(Dry::Validation::VERSION)
-            unless ::Config::DRY_VALIDATION_REQUIREMENTS.all? { |req| Gem::Requirement.new(req).satisfied_by?(version) }
+            unless Config::DRY_VALIDATION_REQUIREMENTS.all? { |req| Gem::Requirement.new(req).satisfied_by?(version) }
               raise LoadError
             end
           rescue LoadError
-            raise ::Config::Error, "Could not find a dry-validation version matching requirements" \
-              " (#{::Config::DRY_VALIDATION_REQUIREMENTS.map(&:inspect) * ","})"
+            raise Config::Error, "Could not find a dry-validation version matching requirements" \
+              " (#{Config::DRY_VALIDATION_REQUIREMENTS.map(&:inspect) * ","})"
           end
           # Delay require until optional schema validation is requested
-          require "dry-validation"
+          require 'dry-validation'
           @schema = Dry::Schema.define(&block)
         else
           @schema

--- a/lib/config/validation/schema.rb
+++ b/lib/config/validation/schema.rb
@@ -1,3 +1,4 @@
+# HACK: This is a temporary fix due to the test suit unloading `Config`
 load 'config/dry_validation_requirements.rb'
 require_relative '../error'
 


### PR DESCRIPTION
- use single quotes (preferred style of the gem)
- use an additional module to be include in both modes (gemspec & rspec) to avoid the unloading of constants